### PR TITLE
Updates for Xcode 11.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: objective-c
-osx_image: xcode10.2
+osx_image: xcode11.2
 before_install:
     - gem install rouge
     - gem install wikipedia-client
 script:
     - swift package update
     - swift package edit CRuby
-    - Packages/CRuby/cfg-cruby --mode rvm --name ruby-2.4.5
+    - Packages/CRuby/cfg-cruby --mode rvm --name ruby-2.6.4
     - cat Packages/CRuby/CRuby.pc
     - sed -ie 's/-lgmp//' Packages/CRuby/CRuby.pc
     - export PKG_CONFIG_PATH=$(pwd)/Packages/CRuby:$PKG_CONFIG_PATH

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.0
+// swift-tools-version:5.1.0
 
 //  Package.swift
 //  RubyGateway
@@ -15,7 +15,7 @@ let package = Package(
             targets: ["RubyGateway", "RubyGatewayHelpers"])
     ],
     dependencies: [
-        .package(url: "https://github.com/johnfairh/CRuby", from: "1.0.0"),
+        .package(url: "https://github.com/johnfairh/CRuby", from: "1.0.1"),
     ],
     targets: [
         .target(

--- a/Tests/RubyGatewayTests/TestClassDef.swift
+++ b/Tests/RubyGatewayTests/TestClassDef.swift
@@ -174,6 +174,12 @@ class TestClassDef: XCTestCase {
 
                 let obj = try inst.getBoundObject(type: MyBoundClass.self)
                 XCTAssertEqual(MyBoundClass.fingerprintValue, obj.fingerprint)
+
+                guard let dummy = RbObject(ofClass: "String") else {
+                    XCTFail("Can't create string!")
+                    return
+                }
+                print("The point of dummy is to overwrite any SwiftBound VALUE on the stack: \(dummy)")
             }
         }
 

--- a/Tests/RubyGatewayTests/TestRbObject.swift
+++ b/Tests/RubyGatewayTests/TestRbObject.swift
@@ -200,6 +200,9 @@ class TestRbObject: XCTestCase {
 
                 XCTAssertEqual(initialMTCount + 1, try getMethodsTestHeapCount())
                 print("Hey Swift, please don't optimize away \(o)")
+
+                let object = RbObject(ofClass: "String")!
+                print("This object is to wipe the stack of refs to 'o's VALUE: \(object)")
             }
         }
 


### PR DESCRIPTION
Fix the GC test once more for Swift 5.1, get CI working on latest everything.
Still should be macOS 10.14 though.