### PR TITLE
Tweaks for Ruby 3.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   macos:
-    name: macOS 12 Xcode
+    name: macOS 12 Xcode Toolchain
     runs-on: macos-12
     strategy:
       fail-fast: false
@@ -58,12 +58,15 @@ jobs:
       matrix:
         rby:
           - short: '2.7'
-            full: '2.7.6'
+            full: '2.7.7'
           - short: '3.0'
-            full: '3.0.4'
+            full: '3.0.5'
             extra_args: '-Xcc -fdeclspec'
           - short: '3.1'
-            full: '3.1.2'
+            full: '3.1.3'
+            extra_args: '-Xcc -fdeclspec'
+          - short: '3.2'
+            full: '3.2.0'
             extra_args: '-Xcc -fdeclspec'
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -166,6 +166,10 @@ log(object2_to_log, priority: 2)
     is installed.
   * RubyGateway requires 'original' MRI/CRuby Ruby - no JRuby/Rubinius/etc.
 
+There's something wrong with the Ruby 3 Xcode project since Ruby 3.2: running
+tests in Xcode shows all kinds of weird errors that look like a linking problem 
+that is not present run normally in SPM.
+
 ## Installation
 
 For macOS, if you are happy to use the system Ruby then you just need to include

--- a/RubyGateway-Ruby3.xcodeproj/project.pbxproj
+++ b/RubyGateway-Ruby3.xcodeproj/project.pbxproj
@@ -591,8 +591,8 @@
 				HEADER_SEARCH_PATHS = (
 					"${SRCROOT}/CRuby/Sources/CRuby",
 					"${SRCROOT}/Sources/RubyGatewayHelpers/include",
-					"$(HOME)/.rbenv/versions/3.1.0/include/ruby-3.1.0",
-					"$(HOME)/.rbenv/versions/3.1.0/include/ruby-3.1.0/x86_64-darwin21",
+					"$(HOME)/.rbenv/versions/3.2.0/include/ruby-3.2.0",
+					"$(HOME)/.rbenv/versions/3.2.0/include/ruby-3.2.0/x86_64-darwin22",
 				);
 				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
 				MTL_ENABLE_DEBUG_INFO = YES;
@@ -648,8 +648,8 @@
 				HEADER_SEARCH_PATHS = (
 					"${SRCROOT}/CRuby/Sources/CRuby",
 					"${SRCROOT}/Sources/RubyGatewayHelpers/include",
-					"$(HOME)/.rbenv/versions/3.1.0/include/ruby-3.1.0",
-					"$(HOME)/.rbenv/versions/3.1.0/include/ruby-3.1.0/x86_64-darwin21",
+					"$(HOME)/.rbenv/versions/3.2.0/include/ruby-3.2.0",
+					"$(HOME)/.rbenv/versions/3.2.0/include/ruby-3.2.0/x86_64-darwin22",
 				);
 				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
 				MTL_ENABLE_DEBUG_INFO = NO;
@@ -719,12 +719,12 @@
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
 				HEADER_SEARCH_PATHS = (
-					"$(HOME)/.rbenv/versions/3.1.0/include/ruby-3.1.0/x86_64-darwin21",
-					"$(HOME)/.rbenv/versions/3.1.0/include/ruby-3.1.0",
+					"$(HOME)/.rbenv/versions/3.2.0/include/ruby-3.2.0/x86_64-darwin22",
+					"$(HOME)/.rbenv/versions/3.2.0/include/ruby-3.2.0",
 				);
 				INFOPLIST_FILE = RubyGateway.xcodeproj/RubyGatewayTests_Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks @loader_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "$(HOME)/.rbenv/versions/3.1.0/lib";
+				LIBRARY_SEARCH_PATHS = "$(HOME)/.rbenv/versions/3.2.0/lib";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited) -Xcc -fdeclspec";
 				PRODUCT_NAME = RubyGatewayTests;
@@ -791,12 +791,12 @@
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
 				HEADER_SEARCH_PATHS = (
-					"$(HOME)/.rbenv/versions/3.1.0/include/ruby-3.1.0/x86_64-darwin21",
-					"$(HOME)/.rbenv/versions/3.1.0/include/ruby-3.1.0",
+					"$(HOME)/.rbenv/versions/3.2.0/include/ruby-3.2.0/x86_64-darwin22",
+					"$(HOME)/.rbenv/versions/3.2.0/include/ruby-3.2.0",
 				);
 				INFOPLIST_FILE = RubyGateway.xcodeproj/RubyGatewayTests_Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks @loader_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "$(HOME)/.rbenv/versions/3.1.0/lib";
+				LIBRARY_SEARCH_PATHS = "$(HOME)/.rbenv/versions/3.2.0/lib";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited) -Xcc -fdeclspec";
 				PRODUCT_NAME = RubyGatewayTests;
@@ -818,12 +818,12 @@
 				);
 				HEADER_SEARCH_PATHS = (
 					"${SRCROOT}/CRuby/Sources/CRuby",
-					"$(HOME)/.rbenv/versions/3.1.0/include/ruby-3.1.0",
-					"$(HOME)/.rbenv/versions/3.1.0/include/ruby-3.1.0/x86_64-darwin21",
+					"$(HOME)/.rbenv/versions/3.2.0/include/ruby-3.2.0",
+					"$(HOME)/.rbenv/versions/3.2.0/include/ruby-3.2.0/x86_64-darwin22",
 				);
 				INFOPLIST_FILE = RubyGateway.xcodeproj/RubyGateway_Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "$(HOME)/.rbenv/versions/3.1.0/lib";
+				LIBRARY_SEARCH_PATHS = "$(HOME)/.rbenv/versions/3.2.0/lib";
 				OTHER_CFLAGS = "";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited) -Xcc -fdeclspec";
@@ -851,12 +851,12 @@
 				);
 				HEADER_SEARCH_PATHS = (
 					"${SRCROOT}/CRuby/Sources/CRuby",
-					"$(HOME)/.rbenv/versions/3.1.0/include/ruby-3.1.0",
-					"$(HOME)/.rbenv/versions/3.1.0/include/ruby-3.1.0/x86_64-darwin21",
+					"$(HOME)/.rbenv/versions/3.2.0/include/ruby-3.2.0",
+					"$(HOME)/.rbenv/versions/3.2.0/include/ruby-3.2.0/x86_64-darwin22",
 				);
 				INFOPLIST_FILE = RubyGateway.xcodeproj/RubyGateway_Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "$(HOME)/.rbenv/versions/3.1.0/lib";
+				LIBRARY_SEARCH_PATHS = "$(HOME)/.rbenv/versions/3.2.0/lib";
 				OTHER_CFLAGS = "";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited) -Xcc -fdeclspec";

--- a/Tests/RubyGatewayTests/Fixtures/methods.rb
+++ b/Tests/RubyGatewayTests/Fixtures/methods.rb
@@ -17,7 +17,7 @@ class MethodsTest
         unless aString.class == String
             raise "Not a string: #{aString.class}"
         end
-        unless aInt.class == Fixnum
+        unless aInt.class == Integer
             raise "Not a fixnum integer: #{aInt.class}"
         end
         unless aFloat.class == Float


### PR DESCRIPTION
`Fixnum` has gone completely, replace with `Integer` in the test that references it.

Update CI.