### PR TITLE
Pluralize "requirements" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ low-level Ruby C API wrapper.
 
 * [Examples](#examples)
 * [Documentation](#documentation)
-* [Requirements](#requirement)
+* [Requirements](#requirements)
 * [Installation](#installation)
 * [Contributions](#contributions)
 * [License](#license)


### PR DESCRIPTION
"Requirements" link in readme wasn't working because it was missing an s.