### PR TITLE
Move Xcode CRuby settings into xcconfig

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
           cat Packages/CRuby/CRuby.pc
           cat Packages/CRuby/Sources/CRuby/module.modulemap
           cat Packages/CRuby/Sources/CRuby/ruby_headers.h
-      - name: Tests
+      - name: Tests (SPM)
         run: |
           export PKG_CONFIG_PATH=$(pwd)/Packages/CRuby:$PKG_CONFIG_PATH
           swift test --enable-code-coverage -Xcc -fdeclspec
@@ -48,6 +48,8 @@ jobs:
         with:
           files: ./coverage.lcov
           verbose: true
+            #      - name: Tests (Xcodebuild)
+            #        run: xcodebuild test -scheme RubyGateway-Package
 
   linux:
     name: ubuntu latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,8 @@ jobs:
         with:
           xcode-version: ${{ matrix.xcode }}
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - name: Ruby
         run: |
           gem install rouge
@@ -49,7 +51,9 @@ jobs:
           files: ./coverage.lcov
           verbose: true
       - name: Tests (Xcodebuild)
-        run: xcodebuild test -scheme RubyGateway-Package
+        run: |
+          CRuby/cfg-cruby --mode custom --path `ruby -e 'puts RbConfig::TOPDIR'`
+          xcodebuild test -scheme RubyGateway-Package
 
   linux:
     name: ubuntu latest
@@ -60,13 +64,9 @@ jobs:
         rby:
           - short: '2.7'
           - short: '3.0'
-            extra_args: '-Xcc -fdeclspec'
           - short: '3.1'
-            extra_args: '-Xcc -fdeclspec'
           - short: '3.2'
-            extra_args: '-Xcc -fdeclspec'
           - short: '3.3'
-            extra_args: '-Xcc -fdeclspec'
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
@@ -94,4 +94,4 @@ jobs:
         run: |
           export PKG_CONFIG_PATH=$(pwd)/Packages/CRuby:$PKG_CONFIG_PATH
           export LD_LIBRARY_PATH=${RB_PREFIX}/lib:$LD_LIBRARY_PATH
-          swift test #${{ matrix.rby.extra_args }}
+          swift test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Tests (SPM)
         run: |
           export PKG_CONFIG_PATH=$(pwd)/Packages/CRuby:$PKG_CONFIG_PATH
-          swift test --enable-code-coverage -Xcc -fdeclspec
+          swift test --enable-code-coverage
       - name: Coverage generation
         run: |
           xcrun llvm-cov export -format lcov .build/debug/RubyGatewayPackageTests.xctest/Contents/MacOS/RubyGatewayPackageTests -instr-profile .build/debug/codecov/default.profdata -ignore-filename-regex "(Test|checkouts)" > coverage.lcov
@@ -48,8 +48,8 @@ jobs:
         with:
           files: ./coverage.lcov
           verbose: true
-            #      - name: Tests (Xcodebuild)
-            #        run: xcodebuild test -scheme RubyGateway-Package
+      - name: Tests (Xcodebuild)
+        run: xcodebuild test -scheme RubyGateway-Package
 
   linux:
     name: ubuntu latest
@@ -94,4 +94,4 @@ jobs:
         run: |
           export PKG_CONFIG_PATH=$(pwd)/Packages/CRuby:$PKG_CONFIG_PATH
           export LD_LIBRARY_PATH=${RB_PREFIX}/lib:$LD_LIBRARY_PATH
-          swift test ${{ matrix.rby.extra_args }}
+          swift test #${{ matrix.rby.extra_args }}

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
             targets: ["RubyGateway", "RubyGatewayHelpers"])
     ],
     dependencies: [
-        .package(url: "https://github.com/johnfairh/CRuby", from: "2.0.0"),
+        .package(url: "https://github.com/johnfairh/CRuby", from: "2.1.0"),
     ],
     targets: [
         .target(

--- a/README.md
+++ b/README.md
@@ -158,27 +158,19 @@ log(object2_to_log, priority: 2)
 
 ## Requirements
 
-* Swift 5.4 or later, from swift.org or Xcode 12.5+
-* macOS (tested on 14.1) or Linux (tested on Ubuntu Bionic/18.04 on x86_64) with Clang 6.
+* Swift 5.9 or later, from swift.org or Xcode 15.3+
+* macOS (tested on 14.1) or Linux (tested on Ubuntu Jammy)
 * Ruby 2.6 or later including development files:
   * For macOS, these come with Xcode.
   * For Linux you may need to install a -dev package depending on how your Ruby
     is installed.
   * RubyGateway requires 'original' MRI/CRuby Ruby - no JRuby/Rubinius/etc.
 
-There's something wrong with the Ruby 3 Xcode project since Ruby 3.2: running
-tests in Xcode shows all kinds of weird errors that look like a linking problem 
-that is not present run normally in SPM.
-
 ## Installation
 
 For macOS, if you are happy to use the system Ruby then you just need to include
 the RubyGateway framework as a dependency.  If you are building on Linux or want
 to use a different Ruby then you also need to configure CRuby.
-
-If you are using Ruby 3 then you need to set the `-fdeclspec` Clang flag, either
-on the Swift PM command line (`swift build -Xcc -fdeclspec`) or in Xcode's
-_Other Swift Flags_ settings.
 
 ### Getting the framework
 
@@ -216,7 +208,7 @@ echo "import RubyGateway; print(Ruby.versionDescription)" > Sources/MyProject/ma
 swift package update
 swift package edit CRuby
 Packages/CRuby/cfg-cruby --mode rbenv --name 3.0.0
-PKG_CONFIG_PATH=$(pwd)/Packages/CRuby:$PKG_CONFIG_PATH swift run -Xcc -fdeclspec
+PKG_CONFIG_PATH=$(pwd)/Packages/CRuby:$PKG_CONFIG_PATH swift run
 ```
 
 ## Contributions

--- a/RubyGateway.xcconfig
+++ b/RubyGateway.xcconfig
@@ -1,13 +1,3 @@
 // Jump over to CRuby for the actual settings.
 // Relative include path means relative to the location of this file.
 #include? "CRuby/CRuby.xcconfig"
-
-// proof of concept...
-
-// Ruby 3 -fdeclspec
-OTHER_CFLAGS = $(inherited) -fdeclspec
-OTHER_SWIFT_FLAGS = $(inherited) -Xcc -fdeclspec
-
-HEADER_SEARCH_PATHS = $(inherited) /Users/johnf/.rbenv/versions/3.3.0/include/ruby-3.3.0/x86_64-darwin23 /Users/johnf/.rbenv/versions/3.3.0/include/ruby-3.3.0
-
-LIBRARY_SEARCH_PATHS = $(inherited) "/Users/johnf/.rbenv/versions/3.3.0/lib"

--- a/RubyGateway.xcconfig
+++ b/RubyGateway.xcconfig
@@ -1,0 +1,9 @@
+// Jump over to CRuby for the actual settings.
+// Relative include path means relative to the location of this file.
+#include? "CRuby/CRuby.xcconfig"
+
+// proof of concept...
+
+// Ruby 3 -fdeclspec
+OTHER_CFLAGS = $(inherited) -fdeclspec
+OTHER_SWIFT_FLAGS = $(inherited) -Xcc -fdeclspec

--- a/RubyGateway.xcconfig
+++ b/RubyGateway.xcconfig
@@ -7,3 +7,7 @@
 // Ruby 3 -fdeclspec
 OTHER_CFLAGS = $(inherited) -fdeclspec
 OTHER_SWIFT_FLAGS = $(inherited) -Xcc -fdeclspec
+
+HEADER_SEARCH_PATHS = $(inherited) /Users/johnf/.rbenv/versions/3.3.0/include/ruby-3.3.0/x86_64-darwin23 /Users/johnf/.rbenv/versions/3.3.0/include/ruby-3.3.0
+
+LIBRARY_SEARCH_PATHS = $(inherited) "/Users/johnf/.rbenv/versions/3.3.0/lib"

--- a/RubyGateway.xcodeproj/project.pbxproj
+++ b/RubyGateway.xcodeproj/project.pbxproj
@@ -143,6 +143,7 @@
 		02901339203ED8D60090C5C9 /* RbConversions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RbConversions.swift; sourceTree = "<group>"; };
 		0290133B203EF0F60090C5C9 /* nonconvert.rb */ = {isa = PBXFileReference; lastKnownFileType = text.script.ruby; path = nonconvert.rb; sourceTree = "<group>"; };
 		0290133C203F42820090C5C9 /* TestMiscObjTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestMiscObjTypes.swift; sourceTree = "<group>"; };
+		02A1D66C2BD1173700B07523 /* RubyGateway.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = RubyGateway.xcconfig; sourceTree = "<group>"; };
 		02ABDBA3216CF7BF00AFDB64 /* RbMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RbMethod.swift; sourceTree = "<group>"; };
 		02ABDBA5216D060300AFDB64 /* TestMethods.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestMethods.swift; sourceTree = "<group>"; };
 		02C5C85020ECD87E007138A2 /* RbComplex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RbComplex.swift; sourceTree = "<group>"; };
@@ -289,6 +290,7 @@
 			isa = PBXGroup;
 			children = (
 				OBJ_6 /* Package.swift */,
+				02A1D66C2BD1173700B07523 /* RubyGateway.xcconfig */,
 				OBJ_7 /* Sources */,
 				OBJ_12 /* Tests */,
 				OBJ_16 /* Dependencies */,
@@ -597,7 +599,6 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
 				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_CFLAGS = "-fdeclspec";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -654,13 +655,13 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
 				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_CFLAGS = "-fdeclspec";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
 		};
 		OBJ_3 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 02A1D66C2BD1173700B07523 /* RubyGateway.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
@@ -732,7 +733,7 @@
 				);
 				LIBRARY_SEARCH_PATHS = "$(HOME)/.rbenv/versions/3.3.0/lib";
 				OTHER_LDFLAGS = "$(inherited)";
-				OTHER_SWIFT_FLAGS = "$(inherited) -Xcc -fdeclspec";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
 				PRODUCT_NAME = RubyGatewayTests;
 				SWIFT_VERSION = 5.0;
 				TARGET_NAME = RubyGatewayTests;
@@ -741,6 +742,7 @@
 		};
 		OBJ_4 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 02A1D66C2BD1173700B07523 /* RubyGateway.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
@@ -810,7 +812,7 @@
 				);
 				LIBRARY_SEARCH_PATHS = "$(HOME)/.rbenv/versions/3.3.0/lib";
 				OTHER_LDFLAGS = "$(inherited)";
-				OTHER_SWIFT_FLAGS = "$(inherited) -Xcc -fdeclspec";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
 				PRODUCT_NAME = RubyGatewayTests;
 				SWIFT_VERSION = 5.0;
 				TARGET_NAME = RubyGatewayTests;
@@ -846,7 +848,7 @@
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++14";
 				OTHER_CFLAGS = "";
 				OTHER_LDFLAGS = "$(inherited)";
-				OTHER_SWIFT_FLAGS = "$(inherited) -Xcc -fdeclspec -enable-experimental-feature AccessLevelOnImport";
+				OTHER_SWIFT_FLAGS = "$(inherited) -enable-experimental-feature AccessLevelOnImport";
 				PRODUCT_BUNDLE_IDENTIFIER = RubyGateway;
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -887,7 +889,7 @@
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++14";
 				OTHER_CFLAGS = "";
 				OTHER_LDFLAGS = "$(inherited)";
-				OTHER_SWIFT_FLAGS = "$(inherited) -Xcc -fdeclspec -enable-experimental-feature AccessLevelOnImport";
+				OTHER_SWIFT_FLAGS = "$(inherited) -enable-experimental-feature AccessLevelOnImport";
 				PRODUCT_BUNDLE_IDENTIFIER = RubyGateway;
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";

--- a/RubyGateway.xcodeproj/project.pbxproj
+++ b/RubyGateway.xcodeproj/project.pbxproj
@@ -592,6 +592,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
 					"${SRCROOT}/CRuby/Sources/CRuby",
 					"${SRCROOT}/Sources/RubyGatewayHelpers/include",
 				);
@@ -646,6 +647,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
 					"${SRCROOT}/CRuby/Sources/CRuby",
 					"${SRCROOT}/Sources/RubyGatewayHelpers/include",
 				);
@@ -817,7 +819,10 @@
 					"$(inherited)",
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
-				HEADER_SEARCH_PATHS = "${SRCROOT}/CRuby/Sources/CRuby";
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"${SRCROOT}/CRuby/Sources/CRuby",
+				);
 				INFOPLIST_FILE = RubyGateway.xcodeproj/RubyGateway_Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -853,7 +858,10 @@
 					"$(inherited)",
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
-				HEADER_SEARCH_PATHS = "${SRCROOT}/CRuby/Sources/CRuby";
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"${SRCROOT}/CRuby/Sources/CRuby",
+				);
 				INFOPLIST_FILE = RubyGateway.xcodeproj/RubyGateway_Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/RubyGateway.xcodeproj/project.pbxproj
+++ b/RubyGateway.xcodeproj/project.pbxproj
@@ -594,8 +594,6 @@
 				HEADER_SEARCH_PATHS = (
 					"${SRCROOT}/CRuby/Sources/CRuby",
 					"${SRCROOT}/Sources/RubyGatewayHelpers/include",
-					"/Users/johnf/.rbenv/versions/3.3.0/include/ruby-3.3.0",
-					"/Users/johnf/.rbenv/versions/3.3.0/include/ruby-3.3.0/x86_64-darwin23",
 				);
 				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
 				MTL_ENABLE_DEBUG_INFO = YES;
@@ -650,8 +648,6 @@
 				HEADER_SEARCH_PATHS = (
 					"${SRCROOT}/CRuby/Sources/CRuby",
 					"${SRCROOT}/Sources/RubyGatewayHelpers/include",
-					"/Users/johnf/.rbenv/versions/3.3.0/include/ruby-3.3.0",
-					"/Users/johnf/.rbenv/versions/3.3.0/include/ruby-3.3.0/x86_64-darwin23",
 				);
 				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
 				MTL_ENABLE_DEBUG_INFO = NO;
@@ -722,16 +718,11 @@
 					"$(inherited)",
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
-				HEADER_SEARCH_PATHS = (
-					"$(HOME)/.rbenv/versions/3.3.0/include/ruby-3.3.0/x86_64-darwin23",
-					"$(HOME)/.rbenv/versions/3.3.0/include/ruby-3.3.0",
-				);
 				INFOPLIST_FILE = RubyGateway.xcodeproj/RubyGatewayTests_Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"@loader_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
-				LIBRARY_SEARCH_PATHS = "$(HOME)/.rbenv/versions/3.3.0/lib";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				PRODUCT_NAME = RubyGatewayTests;
@@ -801,16 +792,11 @@
 					"$(inherited)",
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
-				HEADER_SEARCH_PATHS = (
-					"$(HOME)/.rbenv/versions/3.3.0/include/ruby-3.3.0/x86_64-darwin23",
-					"$(HOME)/.rbenv/versions/3.3.0/include/ruby-3.3.0",
-				);
 				INFOPLIST_FILE = RubyGateway.xcodeproj/RubyGatewayTests_Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"@loader_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
-				LIBRARY_SEARCH_PATHS = "$(HOME)/.rbenv/versions/3.3.0/lib";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				PRODUCT_NAME = RubyGatewayTests;
@@ -831,18 +817,13 @@
 					"$(inherited)",
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
-				HEADER_SEARCH_PATHS = (
-					"${SRCROOT}/CRuby/Sources/CRuby",
-					"/Users/johnf/.rbenv/versions/3.3.0/include/ruby-3.3.0/x86_64-darwin23",
-					"/Users/johnf/.rbenv/versions/3.3.0/include/ruby-3.3.0",
-				);
+				HEADER_SEARCH_PATHS = "${SRCROOT}/CRuby/Sources/CRuby";
 				INFOPLIST_FILE = RubyGateway.xcodeproj/RubyGateway_Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				LIBRARY_SEARCH_PATHS = "$(HOME)/.rbenv/versions/3.3.0/lib";
 				MACOSX_DEPLOYMENT_TARGET = 11.4;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++14";
@@ -872,18 +853,13 @@
 					"$(inherited)",
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
-				HEADER_SEARCH_PATHS = (
-					"${SRCROOT}/CRuby/Sources/CRuby",
-					"/Users/johnf/.rbenv/versions/3.3.0/include/ruby-3.3.0/x86_64-darwin23",
-					"/Users/johnf/.rbenv/versions/3.3.0/include/ruby-3.3.0",
-				);
+				HEADER_SEARCH_PATHS = "${SRCROOT}/CRuby/Sources/CRuby";
 				INFOPLIST_FILE = RubyGateway.xcodeproj/RubyGateway_Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				LIBRARY_SEARCH_PATHS = "$(HOME)/.rbenv/versions/3.3.0/lib";
 				MACOSX_DEPLOYMENT_TARGET = 11.4;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++14";


### PR DESCRIPTION
Time to revamp the Ruby settings and glue.

Update CRuby to hold an xccconfig to have all the custom settings - I suppose I didn't know what xcconfig was back in the day.

Add `xcodebuild` tests to CI.

Remove refs to `-fdeclspec` now no longer needed.