### PR TITLE
Add Ruby 3.4 to linux CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        xcode: ['16.0']
+        xcode: ['16.1']
     steps:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
@@ -69,6 +69,7 @@ jobs:
           - short: '3.1'
           - short: '3.2'
           - short: '3.3'
+          - short: '3.4'
     steps:
       - uses: actions/checkout@v4
         with:

--- a/Sources/RubyGatewayHelpers/include/rbg_helpers.h
+++ b/Sources/RubyGatewayHelpers/include/rbg_helpers.h
@@ -21,6 +21,9 @@
 typedef unsigned long VALUE;
 typedef VALUE ID;
 
+/// Call `RUBY_INIT_STACK`
+void rbg_RUBY_INIT_STACK(void);
+
 /// Safely call `rb_load` and report exception status.
 void rbg_load_protect(VALUE fname, int wrap, int * _Nonnull status);
 

--- a/Sources/RubyGatewayHelpers/rbg_macros.m
+++ b/Sources/RubyGatewayHelpers/rbg_macros.m
@@ -54,3 +54,8 @@ int rbg_qundef(void) { return RUBY_Qundef; }
 // These become inlines in Ruby 3 that get imported
 int rbg_RB_TEST(VALUE v) { return RB_TEST(v); }
 int rbg_RB_NIL_P(VALUE v) { return RB_NIL_P(v); }
+
+// See comment on call in RbVM.swift
+void rbg_RUBY_INIT_STACK(void) {
+    RUBY_INIT_STACK;
+}

--- a/Tests/RubyGatewayTests/TestVM.swift
+++ b/Tests/RubyGatewayTests/TestVM.swift
@@ -111,7 +111,8 @@ class TestVM: XCTestCase {
                 try Ruby.load(filename: Helpers.fixturePath("unloadable.rb"))
                 XCTFail("Managed to load unloadable file")
             } catch RbError.rubyException(let exn) {
-                XCTAssertTrue(exn.description.contains("SyntaxError:"))
+                let desc = exn.description
+                XCTAssertTrue(desc.hasPrefix("SyntaxError:") || desc.hasPrefix("NameError:"))
             }
         }
     }


### PR DESCRIPTION
Update CI for Ruby 3.4.
Fix the unexpected breakage - fixes #51 on macOS as well as Linux.