### PR TITLE
Stop crashes during exception handling

### DIFF
--- a/Sources/RubyGateway/RbError.swift
+++ b/Sources/RubyGateway/RbError.swift
@@ -214,7 +214,7 @@ public struct RbException: CustomStringConvertible, Error {
 
     /// The exception's message
     public var description: String {
-        let exceptionClass = try! exception.get("class")
+        let exceptionClass = (try? exception.get("class")) ?? "(Unknown Ruby exception type)"
         return "\(exceptionClass): \(exception)"
     }
 }


### PR DESCRIPTION
The `try!` in `RbException.description` is a landmine - reliably fails if Ruby is messed up, easiest way to recreate is to remove the `RUBY_INIT_STACK` call.  It turns out Swift itself calls `description` for `try!` via `swift_UnexpectedError`.  We get:
1. `try! require(‘set’)` (or whatever)
2. Ruby fails with `errinfo` set
3. `RbVM.doProtect()` -> `RbError.raise()` does `throw`
4. Swift calls `error.description` 
5. `RbError.description` -> `RbExn.description` -> `try! call(‘class’)`
6. Generates a new error, back to step 4

Fixes #55, #58