### PR TITLE
Update CI for Xcode 16.3 / Swift 6.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,7 +78,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: vapor/swiftly-action@v0.1
+      - uses: vapor/swiftly-action@v0.2
         with:
           toolchain: "6.1"
       - uses: ruby/setup-ruby@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,11 +11,11 @@ on:
 jobs:
   macos:
     name: macOS Xcode Toolchain
-    runs-on: macos-14
+    runs-on: macos-15
     strategy:
       fail-fast: false
       matrix:
-        xcode: ['16.1']
+        xcode: ['16.3']
     steps:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
@@ -80,7 +80,7 @@ jobs:
           persist-credentials: false
       - uses: vapor/swiftly-action@v0.1
         with:
-          toolchain: "6.0"
+          toolchain: "6.1"
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.rby.short }}

--- a/Tests/RubyGatewayTests/TestMethods.swift
+++ b/Tests/RubyGatewayTests/TestMethods.swift
@@ -570,7 +570,7 @@ class TestMethods: XCTestCase {
     func testUserGuideFunctionExamples() {
         struct Logger {
             static nonisolated(unsafe) var logCount = 0
-            static nonisolated(unsafe) func log(message: String?, priority: Int? = nil) {
+            static nonisolated func log(message: String?, priority: Int? = nil) {
                 logCount = logCount + 1
             }
         }


### PR DESCRIPTION
Update CI for Xcode 16.3 / Swift 6.1

Blindly follow compiler's concurrency syntax instructions...